### PR TITLE
Use GOOGLE_APPLICATION_CREDENTIALS for specifying service account

### DIFF
--- a/mc2/data/README.md
+++ b/mc2/data/README.md
@@ -13,7 +13,7 @@ crud.main(
 )
 ```
 
-It requires the filepath of the bigquery credentials to be passed as `creds_loc`. If no argument is passed, the program will try to use the `BQCREDS` environment variable.
+It requires the filepath of the bigquery credentials to be passed as `creds_loc`. If no argument is passed, the program will try to use the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 
 
 While debugging, it could be useful to pass
@@ -36,7 +36,7 @@ python data/crud.py main \
 
 For the production table, the call would be
 ```bash
-export BQCREDS="<path to bigquery creds>"
+export GOOGLE_APPLICATION_CREDENTIALS="<path to bigquery creds>"
 conda activate mc2
 cd mc2
 python data/crud.py main --table_name="missioncontrol_v2_raw_data"

--- a/mc2/data/crud.py
+++ b/mc2/data/crud.py
@@ -43,7 +43,7 @@ def strong_bool(b):
 
 def get_creds(creds_loc=None):
     if not creds_loc:
-        creds_loc = os.environ.get("BQCREDS")
+        creds_loc = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
         if not creds_loc:
             raise RuntimeError(
                 "Bigquery credentials not passed, or found in environment."

--- a/missioncontrol.lib.R
+++ b/missioncontrol.lib.R
@@ -18,7 +18,7 @@ library(rmarkdown)
 options(future.globals.maxSize= 850*1024^2 )
 Lapply <- lapply #future_lapply
 
-BQCREDS <- "~/gcloud.json"
+BQCREDS <- Sys.getenv("GOOGLE_APPLICATION_CREDENTIALS", "~/gcloud.json")
 
 if(!exists("missioncontrol.lib.R")){
     ## executed only once


### PR DESCRIPTION
This is consistent both with Google's recommendations and how we've
built other projects which access bigquery and other GCP resources:

https://cloud.google.com/docs/authentication/getting-started

This will also help make dockerization a bit easier, by making
it possible to store/read google application credentials inside
the local checkout during development.