### PR TITLE
beta pull rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ mc2/test_run_master.sh
 mc2/copy_table.sh
 notebooks/boot_utes.py
 *.fthr
+mc2/data/samp/
+mc2/bin/

--- a/mc2/data/buildhub_bid.py
+++ b/mc2/data/buildhub_bid.py
@@ -3,7 +3,7 @@ import itertools as it
 import re
 from typing import Optional
 
-import pandas as pd
+import pandas as pd  # type: ignore
 from requests import post
 
 uri = "https://buildhub.moz.tools/api/search"

--- a/mc2/data/download_template_single.sql
+++ b/mc2/data/download_template_single.sql
@@ -1,0 +1,242 @@
+-- current_version -> current_versions
+-- replace all {{app_version_field}} = 'current_version'
+
+-- AND {{crash_build_version_field}} IN ({{current_version_crash}}) =>
+    -- AND {{crash_current_versions_dates}}
+
+-- do we need u2.channel_app_version in `usage`?
+-- get rid of `nday`
+-- - min_sub_date
+-- - max_sub_date
+
+CREATE TEMP FUNCTION os_chan_buckets(os string, chan string) as (
+  case (os, chan) when ('Windows_NT', 'release') then 3
+    else 1 end
+);
+
+with usage_base as (
+SELECT
+    --- TOTAL USAGE ON FIREFOX
+    submission_date_s3 as date,
+    os,
+    active_hours_sum,
+    client_id,
+    -- version will be determined by value filled into
+    -- template variable `app_version_field`.
+    {app_version_field} as channel_app_version
+    -- One of app_build_id, displ
+    -- app_version,         -- release
+    -- app_display_version, -- beta
+    -- app_build_id         -- nightly
+  FROM
+    telemetry.clients_daily_v6 
+  WHERE
+    app_name = 'Firefox'
+    and submission_date_s3 between '{min_sub_date}' and '{max_sub_date}'
+    AND os IN ('Linux', 'Windows_NT', 'Darwin')
+    AND normalized_channel = '{norm_channel}'
+    AND MOD(
+      ABS(FARM_FINGERPRINT(MD5(client_id))),
+      os_chan_buckets(os, normalized_channel)
+    ) = 0
+),
+
+usage_current_version as (
+SELECT
+    --- TOTAL USAGE ON FIREFOX
+    date,
+    os,
+    active_hours_sum,
+    client_id,
+    channel_app_version
+  FROM
+    usage_base 
+  WHERE
+    {current_usage_versions_dates}
+),
+
+crashes_base_ as (
+  --- Total Crashes on Current Version
+  --- NEED CLIENT_ID TO JOIN on DAILY TO GET CRASH RATE
+  SELECT
+    client_id,
+    date(submission_timestamp) as date,
+    environment.system.os.name as os,
+    {crash_build_version_field} as channel_app_version_crash,
+    payload
+  FROM
+    telemetry.crash
+  WHERE
+    application.name = 'Firefox'
+    AND environment.system.os.name IN ('Linux', 'Windows_NT', 'Darwin')
+    AND normalized_channel = '{norm_channel}'
+    -- aka 12418
+    AND environment.profile.creation_date >= UNIX_DATE(date('2004-01-01'))
+    -- no more than 2 days into the future
+    AND environment.profile.creation_date <= UNIX_DATE(current_date()) + 2
+    AND MOD(
+      ABS(FARM_FINGERPRINT(MD5(client_id))),
+      os_chan_buckets(environment.system.os.name, normalized_channel)
+    ) = 0
+    AND date(submission_timestamp) between '{min_sub_date}' AND '{max_sub_date}'
+),
+
+crashes_base as (
+  SELECT
+    client_id,
+    date,
+    os,
+    channel_app_version_crash,
+    payload
+  FROM
+    crashes_base_
+  WHERE
+    {crash_current_versions_dates}
+),
+
+--- TOTAL USAGE ON FIREFOX
+u1 as (
+  SELECT
+    date,
+    os,
+    sum(active_hours_sum) as usage_all,
+    count(distinct(client_id)) as dau_all
+  FROM
+    usage_base
+  GROUP BY 1, 2
+),
+
+--- TOTAL USAGE ON FIREFOX ON LATEST VERSION
+--- THIS AND THE ABOVE ARE USED FOR COMPUTING 'NVC'
+u2 as (
+  SELECT
+    date,
+    os,
+    channel_app_version,
+    sum(active_hours_sum) as usage_cversion,
+    count(distinct(client_id)) as dau_cversion
+  FROM
+    usage_current_version
+  GROUP BY 1, 2, 3
+),
+
+usage as (
+  SELECT
+    u1.date,
+    u1.os,
+    u1.usage_all,
+    u1.dau_all,
+    u2.usage_cversion,
+    u2.dau_cversion,
+    u2.channel_app_version
+  FROM
+    u1
+  JOIN
+    u2 ON u1.date = u2.date
+    AND u1.os = u2.os
+),
+
+crashes as (
+  --- Total Crashes on Current Version
+  --- NEED CLIENT_ID TO JOIN on DAILY TO GET CRASH RATE
+  SELECT
+    client_id,
+    date,
+    os,
+    channel_app_version_crash,
+    -- main crash definition at
+    -- https://github.com/mozilla/bigquery-etl/blob/
+    -- 072e4af3b8245c2fc7f4ba5d4c5a87bf10c9c107/sql/
+    -- telemetry_derived/error_aggregates/query.sql#L100
+    countif(payload.process_type = 'main'
+            or payload.process_type is null) as cmain,
+    -- content crash definition at
+    -- https://github.com/mozilla/bigquery-etl/blob/
+    -- 072e4af3b8245c2fc7f4ba5d4c5a87bf10c9c107/sql/
+    -- telemetry_derived/error_aggregates/query.sql#L106
+    countif(regexp_contains(payload.process_type, 'content')
+            and not regexp_contains(
+                coalesce(payload.metadata.ipc_channel_error, ''),
+                'ShutDownKill')
+    ) as ccontent
+  FROM
+    crashes_base
+  GROUP BY 1, 2, 3, 4
+),
+
+--- TOTAL HOURS FROM FOLKS WHO CRASHED
+--- TO COMPUTE CRASH RATE
+crasher_usage as (
+  SELECT
+    client_id,
+    date,
+    os,
+    channel_app_version,
+    sum(active_hours_sum) as usage
+  FROM
+    usage_current_version
+  GROUP BY 1, 2, 3, 4
+),
+
+crashes_nvc as (
+  SELECT
+    cr.date,
+    cr.os,
+    cu.channel_app_version,
+    count(distinct(
+        if(cr.cmain > 0, cr.client_id, null)
+    )) as dau_cm_crasher_cversion,
+    count(distinct(
+        if(cr.ccontent > 0, cr.client_id, null)
+    )) as dau_cc_crasher_cversion,
+    count(distinct(
+        if(cr.cmain > 0 or cr.ccontent > 0, cr.client_id, null)
+    )) as dau_call_crasher_cversion,
+    sum(if(cr.cmain > 0, cu.usage, 0)) as usage_cm_crasher_cversion,
+    sum(if(cr.ccontent > 0, cu.usage, 0)) as usage_cc_crasher_cversion,
+    sum(if(cr.cmain > 0 or cr.ccontent > 0, cu.usage, 0)) as usage_call_crasher_cversion,
+    sum(cmain) as cmain,
+    sum(ccontent) as ccontent,
+    sum(cmain) + sum(ccontent) as call
+  FROM
+    crashes cr
+  JOIN
+    crasher_usage cu ON cr.client_id = cu.client_id
+    AND cr.os = cu.os
+    AND cr.date = cu.date
+    AND cr.channel_app_version_crash = cu.channel_app_version
+  WHERE
+    -- see https://sql.telemetry.mozilla.org/queries/64354/source
+    (cr.ccontent + cr.cmain) < 350
+  GROUP BY 1, 2, 3
+),
+
+res as (
+  SELECT
+    u.date,
+    u.os,
+    u.usage_all,
+    u.dau_all,
+    u.usage_cversion,
+    u.dau_cversion,
+    u.channel_app_version,
+    c.dau_cm_crasher_cversion,
+    c.dau_cc_crasher_cversion,
+    c.dau_call_crasher_cversion,
+    c.usage_cm_crasher_cversion,
+    c.usage_cc_crasher_cversion,
+    c.usage_call_crasher_cversion,
+    c.cmain,
+    c.ccontent,
+    c.call
+  FROM
+    crashes_nvc c
+  JOIN
+    usage u ON c.date = u.date
+    AND c.os = u.os
+    AND c.channel_app_version = u.channel_app_version
+)
+
+SELECT *
+FROM res
+ORDER BY os, date

--- a/mc2/data/download_template_single.sql
+++ b/mc2/data/download_template_single.sql
@@ -1,14 +1,3 @@
--- current_version -> current_versions
--- replace all {{app_version_field}} = 'current_version'
-
--- AND {{crash_build_version_field}} IN ({{current_version_crash}}) =>
-    -- AND {{crash_current_versions_dates}}
-
--- do we need u2.channel_app_version in `usage`?
--- get rid of `nday`
--- - min_sub_date
--- - max_sub_date
-
 CREATE TEMP FUNCTION os_chan_buckets(os string, chan string) as (
   case (os, chan) when ('Windows_NT', 'release') then 3
     else 1 end

--- a/mc2/data/release_versions.py
+++ b/mc2/data/release_versions.py
@@ -1,0 +1,93 @@
+import buildhub_bid as bh
+import pandas as pd  # type: ignore
+
+
+def read_product_details():
+    pd_url = "https://product-details.mozilla.org/1.0/firefox.json"
+    js = pd.read_json(pd_url)
+    df = (
+        pd.DataFrame(js.releases.tolist())
+        .assign(release_label=js.index.tolist())
+        .assign(date=lambda x: pd.to_datetime(x.date))
+    )
+    return df
+
+
+def pull_bh_data_beta(min_build_date):
+    beta_docs = bh.pull_build_id_docs(
+        min_build_day=min_build_date, channel="beta"
+    )
+    return bh.version2build_ids(
+        beta_docs,
+        major_version=None,
+        keep_rc=False,
+        keep_release=False,
+        as_df=True,
+    ).assign(chan="beta")
+    return bh.version2df(
+        beta_docs,
+        keep_rc=False,
+        keep_release=True,
+    ).assign(chan="beta")
+
+
+def get_beta_release_dates(min_build_date="2019", min_pd_date="2019-01-01"):
+    """
+    Stitch together product details and buildhub
+    (for rc builds).
+    - read_product_details()
+    """
+    bh_beta_rc = (
+        pull_bh_data_beta(min_build_date=min_build_date)
+        .rename(columns={"pub_date": "date", "dvers": "version"})
+        .assign(rc=lambda x: x.version.map(is_rc), src="buildhub")
+        .query("rc")[["date", "version", "src"]]
+        .sort_values(["date"], ascending=True)
+        .drop_duplicates(["version"], keep="first")
+    )
+    # return bh_beta_rc
+    prod_details_all = read_product_details()
+    prod_details_beta = prod_details_all.query(
+        f"category == 'dev' & date > '{min_pd_date}'"
+    )[["date", "version"]].assign(src="product-details")
+
+    beta_release_dates = (
+        prod_details_beta.append(bh_beta_rc, ignore_index=False)
+        .assign(
+            maj_vers=lambda x: x.version.map(lambda x: int(x.split(".")[0]))
+        )
+        .sort_values(["date"], ascending=True)
+        .reset_index(drop=1)
+        # Round down datetimes to nearest date
+        .assign(date=lambda x: pd.to_datetime(x.date.dt.date))
+        .astype(str)
+    )
+    return beta_release_dates
+
+
+def is_rc(v):
+    """
+    Is pattern like 69.0, rather than 69.0b3
+    """
+    return "b" not in v
+
+
+def latest_n_release_beta(beta_release_dates, sub_date, n_releases: int = 1):
+    """
+    Given dataframe with beta release dates and a given
+    submission date (can be from the past till today), return the
+    `n_releases` beta versions that were released most recently.
+    beta_release_dates: df[['date', 'version', 'src', 'maj_vers']]
+    """
+    beta_release_dates = beta_release_dates[
+        ["date", "version", "src", "maj_vers"]
+    ]
+    latest = (
+        beta_release_dates
+        # Don't want versions released in the future
+        .query("date < @sub_date")
+        .sort_values(["date"], ascending=True)
+        .iloc[-n_releases:]
+    )
+
+    return latest

--- a/mc2/tests/test_download_bq.py
+++ b/mc2/tests/test_download_bq.py
@@ -18,6 +18,8 @@ def test_rls_version_parse():
 
 
 def test_beta_version_parse():
-    assert beta_version_parse("70.0b3") == {"major": "70", "minor": "3"}
-    assert beta_version_parse("69.0b200") == {"major": "69", "minor": "200"}
-    raises(ValueError, beta_version_parse, "70.0.1")
+    assert beta_version_parse("70.0") == {"major": "70", "minor": None}
+    assert beta_version_parse("70.0b1") == {"major": "70", "minor": "1"}
+    assert beta_version_parse("70.0b200") == {"major": "70", "minor": "200"}
+    assert beta_version_parse("69.0.1") == {"major": "69", "minor": None}
+    assert beta_version_parse("70.0.1b4") == {"major": "70", "minor": "4"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 80

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[testenv]
+extras = test
+commands = pytest {posargs}
+
+[pytest]
+addopts = --verbose
+
+[flake8]
+max-line-length = 80
+ignore = E731,W503


### PR DESCRIPTION
big difference is a new sql template (`download_template_single.sql`) that pulls all beta versions in one fell swoop (as opposed to looping through for each version).

Templating `{variables}` in the sql file are moved to the early subqueries (`crashes_base` and earlier) to make reading a bit easier.

Other changes

* move `read_product_details()` to new module
* apply f-strings
* more flexible `beta_version_parse` (to allow for rc builds)
* allow for specific `sub_date` queries for release
* move channel constants from prod_det_process_* to query_from_row_*
* beta now pulls display_version instead of build_id from crash
* `add_fields_single` function