### PR TITLE
Nightly metadata rewrite

### DIFF
--- a/mc2/data/release_versions.py
+++ b/mc2/data/release_versions.py
@@ -38,6 +38,20 @@ def read_product_details():
     return df
 
 
+def next_release_date(
+    d: "pd.Series[dt.datetime]", max_sub_date: str
+):
+    """
+    d: Series of dates of releases, ordered by time
+    return: date of next release. For most recent release,
+        return `max_sub_date`
+    """
+    # max_date = pd.to_datetime(dt.date.today()) if use_today_as_max else d.max()
+    max_sub_date = pd.to_datetime(max_sub_date)
+    # way_later = max_date + pd.Timedelta(days=max_days_future)
+    return d.shift(-1).fillna(max_sub_date)
+
+
 def pull_bh_data_beta(min_build_date):
     beta_docs = bh.pull_build_id_docs(
         min_build_day=min_build_date, channel="beta"
@@ -85,6 +99,30 @@ def get_beta_release_dates(min_build_date="2019", min_pd_date="2019-01-01"):
         .assign(date=lambda x: pd.to_datetime(x.date.dt.date))
         .astype(str)
     )
+    return beta_release_dates
+
+
+def end_till_date(date: pd.Series, n_days_later, max_sub_date):
+    max_sub_date = pd.to_datetime(max_sub_date)
+    till = pd.to_datetime(date) + pd.Timedelta(days=n_days_later)
+    return np.minimum(till.dt.date, max_sub_date)
+
+
+def prod_det_process_beta(max_sub_date: str, n_total_builds=4, n_days_later=4):
+    beta_release_dates = get_beta_release_dates(
+        min_build_date="2019", min_pd_date="2019-01-01"
+    )
+    beta_release_dates = (
+        beta_release_dates.assign(date=lambda x: pd.to_datetime(x.date))
+        .query(f"date < '{max_sub_date}'")
+        .sort_values(["date"], ascending=True)[-n_total_builds:]
+        # .assign(till=lambda x: x.date + pd.Timedelta(days=n_days_later))
+        .assign(
+            # till=lambda x: end_till_date(x.date, n_days_later, max_sub_date),
+            till=lambda x: next_release_date(x.date, max_sub_date),
+        )
+    )
+
     return beta_release_dates
 
 
@@ -178,6 +216,7 @@ def beta2nightly_version(disp):
 
 def prod_det_process_nightly(
     max_sub_date: Optional[dash_date_fmt] = None,
+    product_details: Optional[pd.DataFrame] = None,
     n_total_builds=4,
     n_days_later=4,
 ):
@@ -188,9 +227,12 @@ def prod_det_process_nightly(
     )
     max_sub_date = to_sub_date_fmt(pd.to_datetime(max_sub_date))
 
-    pd_beta = read_product_details().query(
-        "category == 'dev' & date >= '2019-01'"
-    )[["date", "version"]]
+    product_details = (
+        read_product_details() if product_details is None else product_details
+    )
+    pd_beta = product_details.query("category == 'dev' & date >= '2019-01'")[
+        ["date", "version"]
+    ]
 
     date2disp_version = lookup_latest_release(meta.release_date, pd_beta)
     meta = meta.assign(

--- a/mc2/data/release_versions.py
+++ b/mc2/data/release_versions.py
@@ -1,5 +1,30 @@
+import datetime as dt
+import re
+from collections import OrderedDict
+from typing import Optional
+
 import buildhub_bid as bh
+import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
+
+SUB_DATE_FMT = "%Y-%m-%d"
+BUILD_DAY_FMT = "%Y%m%d"
+dash_date_fmt = str
+
+
+def to_sub_date_fmt(d):
+    return d.strftime(SUB_DATE_FMT)
+
+
+def to_build_day_fmt(d):
+    return d.strftime(BUILD_DAY_FMT)
+
+
+def validate_sub_date_str(d):
+    m = re.match(r"^\d\d\d\d-\d\d-\d\d$", d)
+    assert m, "Date doesn't match format YYYY-MM-dd"
+    assert pd.to_datetime(d)
+    return True
 
 
 def read_product_details():
@@ -24,11 +49,9 @@ def pull_bh_data_beta(min_build_date):
         keep_release=False,
         as_df=True,
     ).assign(chan="beta")
-    return bh.version2df(
-        beta_docs,
-        keep_rc=False,
-        keep_release=True,
-    ).assign(chan="beta")
+    return bh.version2df(beta_docs, keep_rc=False, keep_release=True).assign(
+        chan="beta"
+    )
 
 
 def get_beta_release_dates(min_build_date="2019", min_pd_date="2019-01-01"):
@@ -91,3 +114,90 @@ def latest_n_release_beta(beta_release_dates, sub_date, n_releases: int = 1):
     )
 
     return latest
+
+
+def prod_det_process_nightly_builds(
+    max_sub_date=None, n_total_builds=4, n_days_later=4
+):
+    """
+    `max_sub_date`: "today," or a day that was today at some point
+    `n_total_builds`: if 2, then pull the builds from today and the day before
+    `n_days_later`: if 1, then for each build, pull for activity of
+    that day and the day after.
+    """
+    max_sub_date_ts = pd.to_datetime(max_sub_date or dt.datetime.today())
+    max_sub_date: dt.date = max_sub_date_ts.date()
+
+    build_dates = pd.date_range(end=max_sub_date, periods=n_total_builds)
+    meta = (
+        pd.DataFrame(
+            OrderedDict(
+                [
+                    ("build_id", build_dates.strftime(BUILD_DAY_FMT)),
+                    ("release_date", build_dates),
+                    ("till", build_dates + pd.Timedelta(days=n_days_later)),
+                ]
+            )
+        )
+        .assign(till=lambda x: np.minimum(x.till.dt.date, max_sub_date))
+        .assign(
+            release_date=lambda x: x.release_date.map(to_sub_date_fmt),
+            till=lambda x: x.till.map(to_sub_date_fmt),
+        )
+    )
+    return meta, max_sub_date
+
+
+def lookup_latest_release(dates, release_dates):
+    """
+    release_dates: DataFrame["date", "version"]
+    """
+    # Get a subset of the most recent release dates, starting
+    # with the one just before the minimum `dates` to query,
+    # and ending with the most recent.
+    rls_srtd = release_dates[["date", "version"]].sort_values(
+        ["date"], ascending=True
+    )
+    min_lookup_date = dates.min()  # noqa
+    min_release_date = rls_srtd.query(  # noqa
+        "date <= @min_lookup_date"
+    ).date.iloc[-1]
+    rls_recent = rls_srtd.query("date >= @min_release_date")
+
+    dates_dct = {}
+    for date in dates:
+        dates_dct[date] = rls_recent.query("date <= @date").version.iloc[-1]
+
+    return dates_dct
+
+
+def beta2nightly_version(disp):
+    betav, *_ = disp.split(".")
+    return f"{int(betav) + 1}.0a1"
+
+
+def prod_det_process_nightly(
+    max_sub_date: Optional[dash_date_fmt] = None,
+    n_total_builds=4,
+    n_days_later=4,
+):
+    meta, max_sub_date = prod_det_process_nightly_builds(
+        max_sub_date=max_sub_date,
+        n_total_builds=n_total_builds,
+        n_days_later=n_days_later,
+    )
+    max_sub_date = to_sub_date_fmt(pd.to_datetime(max_sub_date))
+
+    pd_beta = read_product_details().query(
+        "category == 'dev' & date >= '2019-01'"
+    )[["date", "version"]]
+
+    date2disp_version = lookup_latest_release(meta.release_date, pd_beta)
+    meta = meta.assign(
+        current_beta=lambda x: x.release_date.map(date2disp_version)
+    ).assign(
+        nightly_display_version=lambda x: x.current_beta.map(
+            beta2nightly_version
+        )
+    )
+    return meta

--- a/mc2/tests/test_download_bq.py
+++ b/mc2/tests/test_download_bq.py
@@ -18,8 +18,8 @@ def test_rls_version_parse():
 
 
 def test_beta_version_parse():
-    assert beta_version_parse("70.0") == {"major": "70", "minor": None}
+    assert beta_version_parse("70.0") == {"major": "71", "minor": '0'}
     assert beta_version_parse("70.0b1") == {"major": "70", "minor": "1"}
     assert beta_version_parse("70.0b200") == {"major": "70", "minor": "200"}
-    assert beta_version_parse("69.0.1") == {"major": "69", "minor": None}
+    assert beta_version_parse("69.0.1") == {"major": "70", "minor": '0'}
     assert beta_version_parse("70.0.1b4") == {"major": "70", "minor": "4"}

--- a/mc2/tests/test_rv.py
+++ b/mc2/tests/test_rv.py
@@ -1,0 +1,73 @@
+import data.release_versions as rv  # type: ignore
+import pandas as pd  # type: ignore
+from pytest import fixture, raises  # type: ignore
+
+
+def test_prod_det_process_nightly_builds():
+    n_total_builds = 5
+    max_sub_date = "2019-12-10"
+    n_days_later = 3
+    n_builds, _max_sub_date = rv.prod_det_process_nightly_builds(
+        max_sub_date=max_sub_date,
+        n_total_builds=n_total_builds,
+        n_days_later=n_days_later,
+    )
+    assert (
+        (n_builds.applymap(type) == str).all().all()
+    ), "Dataframe should be all strings"
+    assert len(n_builds) == n_total_builds
+    assert n_builds.till.max() <= max_sub_date
+    n_builds_dates = n_builds.apply(pd.to_datetime)
+    max_diff = (
+        (n_builds_dates.till - n_builds_dates.release_date)
+        .astype("timedelta64[D]")
+        .astype(int)
+        .max()
+    )
+    assert max_diff <= n_days_later
+
+
+@fixture
+def release_dates():
+    rows = [
+        ("2011-10-01", "70.0b11"),
+        ("2019-11-15", "71.0b10"),
+        ("2019-11-19", "71.0b11"),
+        ("2019-11-22", "71.0b12"),
+        ("2019-12-03", "72.0b1"),
+        ("2019-12-04", "72.0b2"),
+        ("2019-12-06", "72.0b3"),
+        ("2019-12-09", "72.0b4"),
+        ("2019-12-11", "72.0b5"),
+        ("2019-12-13", "72.0b6"),
+        ("2019-12-16", "72.0b7"),
+        ("2019-12-18", "72.0b8"),
+    ]
+    return pd.DataFrame(rows, columns=["date", "version"])
+
+
+def test_lookup_latest_release(release_dates):
+    dates = pd.Series(
+        ["2019-12-02", "2019-12-16", "2019-12-17", "2019-12-18", "2019-12-19"]
+    )
+    assert rv.lookup_latest_release(dates, release_dates) == {
+        "2019-12-02": "71.0b12",
+        "2019-12-16": "72.0b7",
+        "2019-12-17": "72.0b7",
+        "2019-12-18": "72.0b8",
+        "2019-12-19": "72.0b8",
+    }
+
+
+def test_beta2nightly_version():
+    assert rv.beta2nightly_version("72.0b8") == "73.0a1"
+    assert rv.beta2nightly_version("69.0") == "70.0a1"
+    assert rv.beta2nightly_version("200.0b9") == "201.0a1"
+
+
+def test_validate_sub_date_str():
+    assert rv.validate_sub_date_str("2019-01-01")
+    with raises(ValueError):
+        rv.validate_sub_date_str("2019-14-01")
+    with raises(AssertionError):
+        rv.validate_sub_date_str("2019-01-011")


### PR DESCRIPTION
* rewrite logic to generate metadata for nightly data pull
* groundwork for nightly backfill capability
* groundwork for release backfill capability
* simplify beta product details query (no longer relies on BH for build_id's), but will need for RC